### PR TITLE
Separate bin from hatch lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,12 @@ instructions
 
     git clone git@github.com:hatch-sh/hatch.git && cd hatch
     make setup
+    source .venv/bin/activate
 
 Now you can invoke hatch like this
 
-    .venv/bin/hatch website deploy examples/website
-    .venv/bin/hatch website start examples/website
+    ./bin/hatch website deploy examples/website
+    ./bin/hatch website start examples/website
 
 ## Creating a new release
 

--- a/bin/hatch
+++ b/bin/hatch
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # coding=UTF-8
 # pylint: disable=locally-disabled, C0103
 
@@ -15,7 +16,7 @@ Usage:
 
 Options:
   -h --help            Show this help.
-  --version            Show version.
+  -v --version         Show version.
   --silent             Don't output to stdout.
   --verbose            Output a lot to stdout.
   --config-file <path> Path to configuration file [default: website.yml]

--- a/etc/zsh/_hatch
+++ b/etc/zsh/_hatch
@@ -9,6 +9,7 @@ function _hatch {
         "-h[show help]" \
         "--help[show help]" \
         "--version[Show version]" \
+        "-v[Show version]" \
         "--silent[Don't output to stdout]" \
         "--verbose[Output a lot to stdout]" \
         "--config-file=[Path to configuration file]:file:_files" \

--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,9 @@ setup(
     author='Mads Hartmann Jensen',
     author_email='mads379@gmail.com',
     license='MIT',
-    classifiers=[],
-    keywords=[],
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
     package_data={'': ['README.md']},
+    scripts = ['bin/hatch'],
     install_requires=[
         'boto==2.47.0',
         'boto3==1.4.4',
@@ -38,9 +37,4 @@ setup(
             'pydocstyle==1.1.1'
         ]
     },
-    entry_points={
-        'console_scripts': [
-            'hatch=hatch.cli:run',
-        ]
-    }
 )


### PR DESCRIPTION
How do you feel about this? Notice that `cli.py` has been moved to `./bin/hatch`. I saw that this is how https://github.com/chrisallenlane/cheat does it and I kind of like it