### PR TITLE
Ensure relative paths in config files

### DIFF
--- a/examples/website-relative-path/static/index.html
+++ b/examples/website-relative-path/static/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>hatch example - relative path</title>
+  </head>
+  <body>
+    <h1>Deployed using relative path</h1>
+  </body>
+</html>

--- a/examples/website-relative-path/website.yml
+++ b/examples/website-relative-path/website.yml
@@ -1,0 +1,1 @@
+path: static

--- a/hatch/cli.py
+++ b/hatch/cli.py
@@ -73,11 +73,13 @@ def website_command(arguments):
     path = arguments.get('--path')
     region = arguments.get('--region')
 
+    basepath = os.path.curdir if config_path is None else os.path.dirname(config_path)
+
     file_config = None
     if config_path is None and os.path.isfile('website.yml'):
-        file_config = WebsiteConfig.parse('website.yml')
+        file_config = WebsiteConfig.parse(basepath, 'website.yml')
     elif config_path is not None:
-        file_config = WebsiteConfig.parse(config_path)
+        file_config = WebsiteConfig.parse(basepath, config_path)
 
     arguments_config = WebsiteConfig(path, name, region, domain)
     config = arguments_config.merge(file_config).merge(WebsiteConfig.defaults())

--- a/hatch/config.py
+++ b/hatch/config.py
@@ -5,6 +5,7 @@ import botocore.session
 import boto3
 import uuid
 import sys
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -49,12 +50,13 @@ class WebsiteConfig(object):
         )
 
     @staticmethod
-    def parse(path):
+    def parse(basepath, path):
         try:
             with open(path, 'r') as stream:
                 cfg = yaml.load(stream)
+                path = os.path.join(basepath, cfg.get('path')) if 'path' in cfg else None
                 return WebsiteConfig(
-                    path=cfg.get('path'),
+                    path=path,
                     name=cfg.get('name'),
                     region=get_region(cfg),
                     domain=cfg.get('domain'),


### PR DESCRIPTION
The paths mentioned in config files should be interpreted relative to
the configuration file no matter where you're current directory is